### PR TITLE
Handle redirection for package download

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,6 @@
 # Redirects from what the browser requests to what we serve
 /en/news.rss                /feed.xml
+
+# package download redirect from wllbg.org
+/latest-v2                  https://github.com/wallabag/wallabag/releases/download/2.5.4/wallabag-2.5.4.tar.gz
+/latest-v2-package          https://github.com/wallabag/wallabag/releases/download/2.5.4/wallabag-2.5.4.tar.gz


### PR DESCRIPTION
We still to handle the redirection from `wllbg.org` to `wallabag.org`