### PR TITLE
Use Eleventy Data/ Partials + CSS Fix

### DIFF
--- a/_data/readers.json
+++ b/_data/readers.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "Miniflux",
+    "url": "https://miniflux.net/"
+  },
+  {
+    "name": "Vienna RSS",
+    "url": "http://www.vienna-rss.com/"
+  },
+  {
+    "name": "FreshRSS",
+    "url": "http://www.vienna-rss.com/"
+  },
+  {
+    "name": "Tiny Tiny RSS",
+    "url": "https://tt-rss.org/"
+  },
+  {
+    "name": "Leed",
+    "url": "https://tt-rss.org/"
+  },
+  {
+    "name": "FeedReader",
+    "url": "https://jangernert.github.io/FeedReader/"
+  },
+  {
+    "name": "Fiery Feeds",
+    "url": "https://itunes.apple.com/us/app/fiery-feeds/id1158763303"
+  }
+]

--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -39,7 +39,7 @@
   <nav>
     <ul>
       <li class="">
-        <a href="#features_list"><i class="fa fa-gear"></i>Features List</a>
+        <a href="#features"><i class="fa fa-gear"></i>Features List</a>
       </li>
     </ul>
     <ul>

--- a/_includes/_navigation.html
+++ b/_includes/_navigation.html
@@ -16,7 +16,7 @@
         <div class="col-md-6 col-sm-6 col-xs-6 text-right navicon">
           <p>MENU</p>
           <a id="trigger-overlay" class="nav_slide_button nav-toggle" href="#">
-            <span/>
+            <span></span>
           </a>
         </div>
         {% else %}

--- a/index.html
+++ b/index.html
@@ -146,13 +146,9 @@
               <p>wallabag is supported by many <a href="https://en.wikipedia.org/wiki/News_aggregator">feed aggregators</a> (or RSS readers).</p>
               <p>Here is a non exhaustive list of them.</p>
               <ul class="rss">
-                <li><a href="https://miniflux.net/" class="rss-btn">Miniflux</a></li>
-                <li><a href="http://www.vienna-rss.com/" class="rss-btn">Vienna RSS</a></li>
-                <li><a href="https://freshrss.org/" class="rss-btn">FreshRSS</a></li>
-                <li><a href="https://tt-rss.org/" class="rss-btn">Tiny Tiny RSS</a></li>
-                <li><a href="https://github.com/ldleman/Leed" class="rss-btn">Leed</a></li>
-                <li><a href="https://jangernert.github.io/FeedReader/" class="rss-btn">FeedReader</a></li>
-                <li><a href="https://itunes.apple.com/us/app/fiery-feeds/id1158763303" class="rss-btn">Fiery Feeds</a></li>
+                {% for reader in readers %}
+                <li><a href="{{ reader.url }}" class="rss-btn">{{ reader.name }}</a></li>
+                {% endfor %}
               </ul>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -4,42 +4,7 @@
    </head>
   <body>
 
-    <header>
-      <section class="hero">
-        <div class="texture-overlay"></div>
-        <div class="container">
-          <div class="row nav-wrapper">
-            <div class="col-md-6 col-sm-6 col-xs-6 text-left">
-              <img src="/img/logo-wallabag.svg" alt="wallabag logo">
-            </div>
-            <div class="col-md-6 col-sm-6 col-xs-6 text-right navicon">
-              <p>MENU</p>
-              <a id="trigger-overlay" class="nav_slide_button nav-toggle" href="#">
-                <span/>
-              </a>
-            </div>
-          </div>
-          <div class="row hero-content wp1">
-            <div class="col-md-12">
-              <h1 class="animated fadeIn">
-                Save and classify articles. Read them later. Freely.
-              </h1>
-              <div class="text-center">
-                <a href="#download" class="use-btn">
-                  GET WALLABAG
-                  <i class="fa fa-download"></i></a>
-                <a href="/news" class="use-btn">
-                  NEWS
-                  <i class="fa fa-newspaper-o"></i></a>
-                <a href="https://app.wallabag.it/register" class="use-btn">
-                  TRY IT OUT
-                  <i class="fa fa-user-plus"></i></a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-    </header>
+    {% include "_navigation.html", from_news: false, title: title %}
 
     <div id="content">
       <section class="video" id="video">

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -7000,8 +7000,8 @@ audio,
 canvas,
 video {
 	display: inline-block;
-	*display: inline;
-	*zoom: 1
+	/*display: inline;
+	zoom: 1*/
 }
 
 audio:not([controls]) {
@@ -7208,7 +7208,7 @@ legend {
 	padding: 0;
 	border: 0;
 	white-space: normal;
-	*margin-left: -7px
+	/*margin-left: -7px*/
 }
 
 button,
@@ -7218,7 +7218,7 @@ textarea {
 	margin: 0;
 	vertical-align: baseline;
 	font-size: 100%;
-	*vertical-align: middle
+	/*vertical-align: middle*/
 }
 
 button,
@@ -7232,7 +7232,7 @@ input[type="reset"],
 input[type="submit"] {
 	cursor: pointer;
 	-webkit-appearance: button;
-	*overflow: visible
+	/*overflow: visible*/
 }
 
 button[disabled],
@@ -7244,8 +7244,8 @@ input[type="checkbox"],
 input[type="radio"] {
 	box-sizing: border-box;
 	padding: 0;
-	*height: 13px;
-	*width: 13px
+	/*height: 13px;
+	width: 13px*/
 }
 
 input[type="search"] {
@@ -8176,10 +8176,6 @@ ul.rss li {
 }
 
 @media screen and (max-width:640px) {
-	.use-btn {
-		display: none
-	}
-
 	footer li {
 		display: block;
 		text-align: left;


### PR DESCRIPTION
792d8d23ddf65a2e2db8f46cfe9b40fff7b584be
- Removes `display: none` from `use-btn` class fixing #15 
  - The `use-btn` class is not used anywhere else on the site so this isn't a breaking change
 - Fixes incorrect comment syntax in `static/css/main.css`
 
bf9132fef750aead7aecdfa704156b8f2b262042
 - Moves list of RSS Readers into global data
   - Updating `_data/readers.json` will automatically populate the homepage

39984c1977bc6ce47eff3eb3d8d0d108f4324cab
- Changed an anchor name in `_includes/_footer.html` fixing an issue with the hamburger menu

275ff9f620da4ba9420e8bedaec4182fee903b3e
- The partial `_includes/_navigation.html` was being manually written in `index.html`
- Closed the `span` tag in `_includes/_navigation.html` as `span` is not a [Void Element](https://developer.mozilla.org/en-US/docs/Glossary/Void_element)

> Sorry about the previous PR - I'm horrible with Git