### PR TITLE
feat: Generate release redirects at build time with latest release from Github

### DIFF
--- a/_data/github.js
+++ b/_data/github.js
@@ -1,7 +1,7 @@
 const fetch = require("node-fetch");
 
 module.exports = async function() {
-  console.log( "Fetching new github stargazers count…" );
+  console.log( "Fetching Github latest release" );
 
   // GitHub API: https://developer.github.com/v3/repos/#get
   return fetch("https://api.github.com/repos/wallabag/wallabag/releases/latest")

--- a/_data/github.js
+++ b/_data/github.js
@@ -1,0 +1,15 @@
+const fetch = require("node-fetch");
+
+module.exports = async function() {
+  console.log( "Fetching new github stargazers count…" );
+
+  // GitHub API: https://developer.github.com/v3/repos/#get
+  return fetch("https://api.github.com/repos/wallabag/wallabag/releases/latest")
+    .then(res => res.json()) // node-fetch option to transform to json
+    .then(json => {
+      // prune the data to return only what we want
+      return {
+        appVersion: json.name
+      };
+    });
+};

--- a/_includes/_download.html
+++ b/_includes/_download.html
@@ -4,7 +4,7 @@
       <div class="col-md-12 text-center wp4">
         <h1>Want to give it a try?</h1>
         <p><a href="https://www.wallabag.it/" class="download-btn">REGISTER <i class="fa fa-user-plus"></i></a> <a href="https://doc.wallabag.org/en/admin/installation/installation.html#installation" class="download-btn">DOWNLOAD <i class="fa fa-download"></i></a><br></p>
-        <p>Last release: wallabag 2.6.1<br>
+        <p>Last release: wallabag {{ github.appVersion }}<br>
           (md5 checksum: 290bf49526ebebc77ab1711005a01e88)<br>
             You can download our <a href="{{ site.metadata.repo }}/releases" target="_blank">previous releases here</a>.</p>
       </div>

--- a/_redirects
+++ b/_redirects
@@ -1,7 +1,0 @@
-# Redirects from what the browser requests to what we serve
-/en/news.rss                /feed.xml
-/feeds/all.atom.xml         /feed.xml
-
-# package download redirect from wllbg.org
-/latest-v2                  https://github.com/wallabag/wallabag/releases/download/2.6.1/wallabag-2.6.1.tar.gz
-/latest-v2-package          https://github.com/wallabag/wallabag/releases/download/2.6.1/wallabag-2.6.1.tar.gz

--- a/_redirects.njk
+++ b/_redirects.njk
@@ -1,0 +1,11 @@
+---
+permalink: /_redirects
+eleventyExcludeFromCollections: true
+---
+# Redirects from what the browser requests to what we serve
+/en/news.rss                /feed.xml
+/feeds/all.atom.xml         /feed.xml
+
+# package download redirect from wllbg.org
+/latest-v2                  https://github.com/wallabag/wallabag/releases/download/{{ github.appVersion }}/wallabag-{{ github.appVersion }}.tar.gz
+/latest-v2-package          https://github.com/wallabag/wallabag/releases/download/{{ github.appVersion }}/wallabag-{{ github.appVersion }}.tar.gz

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
             "devDependencies": {
                 "@11ty/eleventy": "^2.0.1",
                 "@11ty/eleventy-plugin-rss": "^1.2.0",
-                "luxon": "^3.3.0"
+                "luxon": "^3.3.0",
+                "node-fetch": "^2.6.7"
             }
         },
         "node_modules/@11ty/dependency-tree": {
@@ -1626,6 +1627,26 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
+        "node_modules/node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "dev": true,
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2254,6 +2275,12 @@
             "integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==",
             "dev": true
         },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "dev": true
+        },
         "node_modules/uc.micro": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -2289,6 +2316,22 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "dev": true
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dev": true,
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "devDependencies": {
         "@11ty/eleventy": "^2.0.1",
         "@11ty/eleventy-plugin-rss": "^1.2.0",
-        "luxon": "^3.3.0"
+        "luxon": "^3.3.0",
+        "node-fetch": "^2.6.7"
     }
 }


### PR DESCRIPTION
I've noticed that you update manually links to the latest release with version.
This PR will use the latest release version directly from Github api.

One thing that I was not able to retrieve is the md5 checksum. 
How do you calculate it, from what I know there is no way to retrieve it from API (but I may be wrong) ? 