### PR TITLE
Blog post about 2.6.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,7 @@ updates:
     interval: daily
     time: "02:00"
     timezone: Europe/Paris
-  open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js ⚙️
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/src/_includes/_download.html
+++ b/src/_includes/_download.html
@@ -5,7 +5,7 @@
         <h1>Want to give it a try?</h1>
         <p><a href="https://www.wallabag.it/" class="download-btn">REGISTER <i class="fa fa-user-plus"></i></a> <a href="https://doc.wallabag.org/en/admin/installation/installation.html#installation" class="download-btn">DOWNLOAD <i class="fa fa-download"></i></a><br></p>
         <p>Last release: wallabag {{ github.appVersion }}<br>
-          (md5 checksum: 9289a87a231d3d01ede5b471d9c87c10)<br>
+          (md5 checksum: d02126f55874b8c9e47fe049c5a24236)<br>
             You can download our <a href="{{ site.metadata.repo }}/releases" target="_blank">previous releases here</a>.</p>
       </div>
     </div>

--- a/src/news/20240103-new-release-wallabag-268/index.md
+++ b/src/news/20240103-new-release-wallabag-268/index.md
@@ -1,0 +1,49 @@
+---
+title: 'wallabag 2.6.8'
+published: true
+date: 2024-01-03 11:00:00 +02:00
+---
+
+First of all, happy new year to every one! Stay safe and healthy.
+
+Here is the latest release of wallabag.
+
+📈  **To update your instance**, [just run `make update`](https://doc.wallabag.org/en/admin/upgrade.html).
+Don't forget to make a backup of your instance (database and files).
+
+_🤝  A little reminder that **you can support our work** on wallabag by sponsoring us on [Liberapay](https://liberapay.com/wallabag) or subscribe on [wallabag.it](https://www.wallabag.it/en). Thanks!_
+
+## Human summary
+We fixed an issue in dark mode and removed the session-based redirection which was bugged. Site configs are also up to date (huge thanks to @HolgerAusB).
+
+Technically, we are now using Node 20 to build assets.
+
+## What's Changed
+* Update deps & Node 20 by @j0k3r in [#7134](https://github.com/wallabag/wallabag/pull/7134)
+* Fix dark mode disabled url 2.6 by @Simounet in [#7133](https://github.com/wallabag/wallabag/pull/7133)
+* Make database dependent commands lazy by @yguedidi in [#7142](https://github.com/wallabag/wallabag/pull/7142)
+* Fix docker setup by @yguedidi in [#7141](https://github.com/wallabag/wallabag/pull/7141)
+* Remove session-based redirection by @yguedidi in [#7140](https://github.com/wallabag/wallabag/pull/7140)
+* Prepare 2.6.8 release by @j0k3r in [#7143](https://github.com/wallabag/wallabag/pull/7143)
+
+You can read the [full changelog](https://github.com/wallabag/wallabag/compare/2.6.7...2.6.8) on GitHub.
+
+## Download wallabag 2.6.8
+
+To download, install/upgrade wallabag, [please read our downloads page](https://doc.wallabag.org/en/admin/installation/installation.html).
+
+<hr />
+
+## Need help?
+
+[We are on Gitter](https://gitter.im/wallabag/wallabag), ping us!
+
+You can also open a [new issue on GitHub](https://github.com/wallabag/wallabag/issues/new/choose).
+
+<hr />
+
+## How can you help us?
+
+By using wallabag, by reporting bugs, by translating wallabag and its documentation, by talking about wallabag to your friends, ...
+
+You can also help us by donating via [Liberapay](https://liberapay.com/wallabag/).


### PR DESCRIPTION
See https://github.com/wallabag/wallabag/releases/tag/2.6.8

Also update GitHub Actions and enable Dependabot to update them in the future.