### PR TITLE
Add linkt to Safari extension

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -92,6 +92,7 @@
                   <li><a href="https://chrome.google.com/webstore/detail/wallabagger/gbmgphmejlcoihgedabhgjdkcahacjlj" class="download-btn">Chrome <i class="fa fa-chrome"></i></a></li>
                   <li><a href="https://addons.mozilla.org/firefox/addon/wallabagger/" class="download-btn">Firefox <i class="fa fa-firefox"></i></a></li>
                   <li><a href="https://addons.opera.com/en/extensions/details/wallabagger/" class="download-btn">Opera <i class="fa fa-opera"></i></a></li>
+                  <li><a href="https://apps.apple.com/de/app/wallabag-quicksave/id1621482657" class="download-btn">Safari <i class="fa fa-safari"></i></a></li>
                   <li><a href="http://plop-reader.pascal-martin.fr/" class="download-btn">PocketBook<i class="fa fa-tablet"></i></a></li>
                   <li><a href="https://gitlab.com/anarcat/wallabako" class="download-btn">Kobo<i class="fa fa-tablet"></i></a></li>
                   <li><a href="https://github.com/cekage/wallindle" class="download-btn">Kindle<i class="fa fa-tablet"></i></a></li>


### PR DESCRIPTION
I've created a Safari extension a while back. The source code can be found here: https://github.com/jandamm/wallabag-macos